### PR TITLE
Remove wrong explanation in code for optional metacharacter

### DIFF
--- a/gnu_awk.md
+++ b/gnu_awk.md
@@ -709,7 +709,7 @@ $ # same as: awk '{gsub(/part|parrot|parent/, "X")} 1'
 $ echo 'par part parrot parent' | awk '{gsub(/par(en|ro)?t/, "X")} 1'
 par X X X
 
-$ # '<' to be replaced with '\<' only if not preceded by '\'
+$ # '<' to be replaced with '\<' optionally preceded by '\'
 $ echo 'blah \< foo bar < blah baz <' | awk '{gsub(/\\?</, "\\<")} 1'
 blah \< foo bar \< blah baz \<
 ```


### PR DESCRIPTION
Here all `'<'` is replaced with `'\<'` optionally preceded by `'\'` not only if not preceded by `'\'`. A way to prove can be just change the code & run
```bash
$ echo 'blah \< foo bar < blah baz <' | awk '{gsub(/\\?</, "X")} 1'
blah X foo bar X blah baz X
```